### PR TITLE
fix: enable window dragging when command palette is active

### DIFF
--- a/Alto/Browser/Views/CommandPalette/CommandPaletteView.swift
+++ b/Alto/Browser/Views/CommandPalette/CommandPaletteView.swift
@@ -21,6 +21,7 @@ struct CommandPaletteView: View {
                 .onTapGesture {
                     viewModel.handleDismiss(altoState: altoState)
                 }
+                .gesture(WindowDragGesture())
 
             VStack {
                 VStack(spacing: 0) {


### PR DESCRIPTION
Adds WindowDragGesture to the command palette background overlay
to allow window dragging even when the palette is visible.


https://github.com/user-attachments/assets/016c58d2-353d-4857-858e-91cc7cb44da4